### PR TITLE
Fix start up error for Windows

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-await import(resolve(__dirname, "..", "dist", "index.js"));
+await import(pathToFileURL(resolve(__dirname, "..", "dist", "index.js")).href);


### PR DESCRIPTION
## Fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows — use  URLs for ESM imports

### Environment
- **OS:** Windows
- **Node.js:** v22.11.0
- **Usage:** VS Code MCP server (`npx -y football-docs`)

### Problem

The server fails to start on Windows with the following error:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

Node.js ESM requires absolute paths to be passed as valid  URLs when using dynamic `import()`. On Linux/macOS, bare absolute paths (e.g. `/usr/...`) happen to work, but on Windows, paths like `c:\...` are invalid ESM URL schemes and cause a hard crash.

### Solution

Use Node's built-in `pathToFileURL` to convert the path before passing it to `import()`:

```js
import { pathToFileURL } from 'url';

// Before
await import(absolutePath);

// After
await import(pathToFileURL(absolutePath).href);
```

This is safe cross-platform — `pathToFileURL` produces valid  URLs on all operating systems.